### PR TITLE
Se hizo la tarea del azure de filtrar por estado en incidencias 

### DIFF
--- a/Endpoints/Incidencia.js
+++ b/Endpoints/Incidencia.js
@@ -521,4 +521,106 @@ router.get('/reporte', async(req, res) => {
     }
 });
 
+/**
+ * @swagger
+ * /incidencias/filtrar:
+ *   get:
+ *     summary: Obtener incidencias filtradas por estado
+ *     description: Retorna una lista de incidencias filtradas según su estado.
+ *     tags: [Incidencias]
+ *     parameters:
+ *       - in: query
+ *         name: estado
+ *         required: false
+ *         description: Estado de la incidencia.
+ *         schema:
+ *           type: string
+ *           enum: [Pendiente, Resuelto, En Proceso]
+ *           example: Pendiente
+ *     responses:
+ *       200:
+ *         description: Lista de incidencias obtenida correctamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 incidencias:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       _id:
+ *                         type: string
+ *                         description: ID único de la incidencia
+ *                         example: "60f4e3b4d8b9b40015c68409"
+ *                       descripcion:
+ *                         type: string
+ *                         description: Descripción de la incidencia
+ *                         example: "Falla en el motor del autobús."
+ *                       idAutoBus:
+ *                         type: string
+ *                         description: ID del autobús asociado
+ *                         example: "605c72ef1532071b7c8c8a12"
+ *                       reportadoPor:
+ *                         type: string
+ *                         description: ID del usuario que reportó la incidencia
+ *                         example: "60f4e3b4d8b9b40015c68408"
+ *                       estado:
+ *                         type: string
+ *                         description: Estado actual de la incidencia
+ *                         example: "Pendiente"
+ *                       fechaDeReporte:
+ *                         type: string
+ *                         format: date-time
+ *                         description: Fecha en que se reportó la incidencia
+ *                         example: "2025-02-19T14:30:00.000Z"
+ *       400:
+ *         description: Parámetro de estado inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "El estado proporcionado no es válido"
+ *       500:
+ *         description: Error interno del servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Hubo un error al obtener las incidencias"
+ */
+
+
+
+router.get('/filtrar', async (req, res) => {
+    try {
+        let { estado } = req.query;
+        const estadosValidos = ['Pendiente', 'Resuelto', 'En Proceso'];
+        
+        if (!estadosValidos.includes(estado)) {
+            return res.status(400).json({ message: 'Estado no válido. Debe ser Pendiente, Resuelto o En Proceso.' });
+        }
+        
+        const incidencias = await IncidenciaSchema.find({estado})
+            .sort({ fechaDeReporte: -1 });
+        
+        if (incidencias.length === 0) {
+            return res.status(200).json({ message: 'No hay incidencias con este estado.' });
+        }
+        
+        res.status(200).json({ incidencias });
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ message: 'Hubo un error al obtener las incidencias', error: err });
+    }
+});
+
+
 module.exports = router;


### PR DESCRIPTION
# 🚀 Descripción
Se agregó un nuevo endpoint para filtrar incidencias por estado, permitiendo obtener solo aquellas que sean `Pendiente`, `Resuelto` o `En Proceso`. Además, se documentó correctamente en Swagger.

# 🛠 ¿Qué se hizo?
- [x] Agregada nueva funcionalidad: Endpoint `GET /incidencia/filtrar` para filtrar incidencias por estado  
- [x] Mejorada la documentación: Se agregó la especificación en Swagger  

# 🧪 ¿Cómo probarlo?
1. Ejecutar `npm start`  
2. Acceder a `http://localhost:3001/docs/#/` para visualizar la documentación en Swagger  
3. Hacer una solicitud `GET /incidencia/filtrar?estado=Pendiente` desde Insomnia 
4. Verificar que solo se devuelvan incidencias con el estado solicitado  

# 🔍 Revisores
@DavielSanchez  
